### PR TITLE
Add CachedUncertain, #[no_std] compatible version of BoxedUncertain

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 
 /// Boxed uncertain value. An uncertain value which can
 /// be cloned. See [`Uncertain::into_boxed`].
+#[deprecated(since = "0.2.1", note = "Please use `CachedUncertain` instead")]
 pub struct BoxedUncertain<U>
 where
     U: Uncertain,

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -9,7 +9,7 @@ where
     U: Uncertain,
     U::Value: Clone,
 {
-    ptr: U,
+    uncertain: U,
     cache: Cell<Option<(usize, U::Value)>>,
 }
 

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -2,7 +2,7 @@ use crate::Uncertain;
 use rand::Rng;
 use std::cell::Cell;
 
-/// Cached uncertainty. Its reference also implements Uncertain.
+/// Cached uncertain value. Allows its reference to also implements [`Uncertain`].
 /// See [`Uncertain::into_cached`].
 pub struct CachedUncertain<U>
 where

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -1,0 +1,73 @@
+use crate::Uncertain;
+use rand::Rng;
+use std::cell::Cell;
+
+/// Cached uncertainty. Its reference also implements Uncertain.
+/// See [`Uncertain::into_cached`].
+pub struct CachedUncertain<U>
+where
+    U: Uncertain,
+    U::Value: Clone,
+{
+    ptr: U,
+    cache: Cell<Option<(usize, U::Value)>>,
+}
+
+impl<U> CachedUncertain<U>
+where
+    U: Uncertain,
+    U::Value: Clone,
+{
+    pub(crate) fn new(contained: U) -> Self {
+        CachedUncertain {
+            ptr: contained,
+            cache: Cell::new(None),
+        }
+    }
+}
+
+impl<U> Uncertain for &CachedUncertain<U>
+where
+    U: Uncertain,
+    U::Value: Clone,
+{
+    type Value = U::Value;
+
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R, epoch: usize) -> Self::Value {
+        let value = match self.cache.take() {
+            Some((cache_epoch, cache_value)) if cache_epoch == epoch => cache_value,
+            _ => self.ptr.sample(rng, epoch),
+        };
+        self.cache.set(Some((epoch, value.clone())));
+        value
+    }
+}
+
+impl<U> Uncertain for CachedUncertain<U>
+where
+    U: Uncertain,
+    U::Value: Clone,
+{
+    type Value = U::Value;
+
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R, epoch: usize) -> Self::Value {
+        <&Self as Uncertain>::sample(&self, rng, epoch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Distribution, Uncertain};
+    use rand_distr::Normal;
+    use rand_pcg::Pcg32;
+
+    #[test]
+    fn cached_uncertain_shares_values() {
+        let x = Distribution::from(Normal::new(10.0, 1.0).unwrap());
+        let x = x.into_cached();
+        let mut rng = Pcg32::new(0xcafef00dd15ea5e5, 0xa02bdbf7bb3c0a7);
+        for epoch in 0..1000 {
+            assert_eq!((&x).sample(&mut rng, epoch), (&x).sample(&mut rng, epoch));
+        }
+    }
+}

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -20,7 +20,7 @@ where
 {
     pub(crate) fn new(contained: U) -> Self {
         CachedUncertain {
-            ptr: contained,
+            uncertain: contained,
             cache: Cell::new(None),
         }
     }
@@ -36,7 +36,7 @@ where
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R, epoch: usize) -> Self::Value {
         let value = match self.cache.take() {
             Some((cache_epoch, cache_value)) if cache_epoch == epoch => cache_value,
-            _ => self.ptr.sample(rng, epoch),
+            _ => self.uncertain.sample(rng, epoch),
         };
         self.cache.set(Some((epoch, value.clone())));
         value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![allow(clippy::float_cmp)]
 
 //! Computation with uncertain values.
 //!
@@ -40,11 +41,13 @@
 //! [sprt]: https://en.wikipedia.org/wiki/Sequential_probability_ratio_test
 
 use adapters::*;
+use cached::CachedUncertain;
 use rand::Rng;
 use rand_pcg::Pcg32;
 
 mod adapters;
 mod boxed;
+mod cached;
 mod dist;
 mod sprt;
 
@@ -162,6 +165,41 @@ pub trait Uncertain {
         Self::Value: Clone,
     {
         BoxedUncertain::new(self)
+    }
+
+    /// Bundle this uncertain value with a cache, so it can be reused in a calculation.
+    /// Usually, an uncertain value can not be reused in a network as the [`Distribution`]
+    /// type does not implement Clone, while the reference of CachedUncertain implements
+    /// Uncertain and can be used multiple times in a calculation.
+    ///
+    /// it has to cache it's sampled value by means of interior mutability such that if it is
+    /// queried for the same `epoch` twice, it returns the same value.
+    ///
+    /// [`CachedUncertain`] wraps the uncertain value contained in  `self`, and
+    /// ensures it behaves correctly if sampled repeatedly.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use uncertain::{Uncertain, Distribution};
+    /// use rand_distr::Normal;
+    ///
+    /// let x = Distribution::from(Normal::new(5.0, 2.0).unwrap()).into_cached();
+    /// let y = Distribution::from(Normal::new(10.0, 5.0).unwrap());
+    /// let a = (&x).add(y);
+    /// let b = a.add(&x);
+    ///
+    /// let bigger_than_twelve = b.map(|v| v > 12.0);
+    /// assert!(bigger_than_twelve.pr(0.5));
+    /// ```
+    fn into_cached(self) -> CachedUncertain<Self>
+    where
+        Self: Sized,
+        Self::Value: Clone,
+    {
+        CachedUncertain::new(self)
     }
 
     /// Takes an uncertain value and produces another which

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ pub trait Uncertain {
     /// let bigger_than_twelve = b.map(|v| v > 12.0);
     /// assert!(bigger_than_twelve.pr(0.5));
     /// ```
+    #[deprecated(since = "0.2.1", note = "Please use `into_cached` instead")]
     fn into_boxed(self) -> BoxedUncertain<Self>
     where
         Self: 'static + Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,15 +168,10 @@ pub trait Uncertain {
     }
 
     /// Bundle this uncertain value with a cache, so it can be reused in a calculation.
-    /// Usually, an uncertain value can not be reused in a network as the [`Distribution`]
-    /// type does not implement Clone, while the reference of CachedUncertain implements
-    /// Uncertain and can be used multiple times in a calculation.
-    ///
-    /// it has to cache it's sampled value by means of interior mutability such that if it is
-    /// queried for the same `epoch` twice, it returns the same value.
-    ///
-    /// [`CachedUncertain`] wraps the uncertain value contained in  `self`, and
-    /// ensures it behaves correctly if sampled repeatedly.
+    /// Normally, uncertain values do not implement `Copy` or `Clone`, since the same value
+    /// is only allowed to be sampled once for every epoch. The cache added by this wrapper
+    /// allows a value to be reused, by caching the sample result for every epoch and implementing
+    /// [`Uncertain`] for references as well.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The `Rc` in `BoxedUncertain` is unnecessary as `Cell` can be mutated behind an immutable reference. `CachedUncertain` provides the same functionality as `BoxedUncertain` by implementing `Uncertain` on its references.