### PR TITLE
Allow boxing uncertain as a trait object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["algorithms", "mathematics", "science", "simulation"]
 exclude = [".github"]
 
 [dependencies]
-rand = "0.8.3"
+rand = "0.8.0"
 rand_pcg = "0.3.0"
 
 [dev-dependencies]

--- a/src/adapters/flat_map.rs
+++ b/src/adapters/flat_map.rs
@@ -1,4 +1,4 @@
-use crate::{Rng, Uncertain, UncertainBase};
+use crate::{Rng, Uncertain};
 
 pub struct FlatMap<U, F> {
     uncertain: U,
@@ -16,7 +16,7 @@ where
     }
 }
 
-impl<O, U, F> UncertainBase for FlatMap<U, F>
+impl<O, U, F> Uncertain for FlatMap<U, F>
 where
     U: Uncertain,
     O: Uncertain,

--- a/src/adapters/flat_map.rs
+++ b/src/adapters/flat_map.rs
@@ -1,5 +1,4 @@
-use crate::Uncertain;
-use rand::Rng;
+use crate::{Rng, Uncertain, UncertainBase};
 
 pub struct FlatMap<U, F> {
     uncertain: U,
@@ -17,7 +16,7 @@ where
     }
 }
 
-impl<O, U, F> Uncertain for FlatMap<U, F>
+impl<O, U, F> UncertainBase for FlatMap<U, F>
 where
     U: Uncertain,
     O: Uncertain,
@@ -25,7 +24,7 @@ where
 {
     type Value = O::Value;
 
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R, epoch: usize) -> Self::Value {
+    fn sample(&self, rng: &mut Rng, epoch: usize) -> Self::Value {
         let v = self.uncertain.sample(rng, epoch);
         (self.func)(v).sample(rng, epoch)
     }

--- a/src/adapters/join.rs
+++ b/src/adapters/join.rs
@@ -1,5 +1,4 @@
-use crate::Uncertain;
-use rand::Rng;
+use crate::{Rng, Uncertain, UncertainBase};
 
 pub struct Join<A, B, F> {
     a: A,
@@ -18,7 +17,7 @@ where
     }
 }
 
-impl<O, A, B, F> Uncertain for Join<A, B, F>
+impl<O, A, B, F> UncertainBase for Join<A, B, F>
 where
     A: Uncertain,
     B: Uncertain,
@@ -26,7 +25,7 @@ where
 {
     type Value = O;
 
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R, epoch: usize) -> Self::Value {
+    fn sample(&self, rng: &mut Rng, epoch: usize) -> Self::Value {
         let a = self.a.sample(rng, epoch);
         let b = self.b.sample(rng, epoch);
         (self.func)(a, b)

--- a/src/adapters/join.rs
+++ b/src/adapters/join.rs
@@ -1,4 +1,4 @@
-use crate::{Rng, Uncertain, UncertainBase};
+use crate::{Rng, Uncertain};
 
 pub struct Join<A, B, F> {
     a: A,
@@ -17,7 +17,7 @@ where
     }
 }
 
-impl<O, A, B, F> UncertainBase for Join<A, B, F>
+impl<O, A, B, F> Uncertain for Join<A, B, F>
 where
     A: Uncertain,
     B: Uncertain,

--- a/src/adapters/map.rs
+++ b/src/adapters/map.rs
@@ -1,4 +1,4 @@
-use crate::{Rng, Uncertain, UncertainBase};
+use crate::{Rng, Uncertain};
 
 pub struct Map<U, F> {
     uncertain: U,
@@ -15,7 +15,7 @@ where
     }
 }
 
-impl<T, U, F> UncertainBase for Map<U, F>
+impl<T, U, F> Uncertain for Map<U, F>
 where
     U: Uncertain,
     F: Fn(U::Value) -> T,

--- a/src/adapters/map.rs
+++ b/src/adapters/map.rs
@@ -1,5 +1,4 @@
-use crate::Uncertain;
-use rand::Rng;
+use crate::{Rng, Uncertain, UncertainBase};
 
 pub struct Map<U, F> {
     uncertain: U,
@@ -16,14 +15,14 @@ where
     }
 }
 
-impl<T, U, F> Uncertain for Map<U, F>
+impl<T, U, F> UncertainBase for Map<U, F>
 where
     U: Uncertain,
     F: Fn(U::Value) -> T,
 {
     type Value = T;
 
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R, epoch: usize) -> Self::Value {
+    fn sample(&self, rng: &mut Rng, epoch: usize) -> Self::Value {
         let v = self.uncertain.sample(rng, epoch);
         (self.func)(v)
     }

--- a/src/adapters/ops.rs
+++ b/src/adapters/ops.rs
@@ -1,5 +1,4 @@
-use crate::Uncertain;
-use rand::Rng;
+use crate::{Rng, Uncertain, UncertainBase};
 
 pub struct Not<U>
 where
@@ -19,14 +18,14 @@ where
     }
 }
 
-impl<U> Uncertain for Not<U>
+impl<U> UncertainBase for Not<U>
 where
     U: Uncertain,
     U::Value: Into<bool>,
 {
     type Value = bool;
 
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R, epoch: usize) -> Self::Value {
+    fn sample(&self, rng: &mut Rng, epoch: usize) -> Self::Value {
         !self.uncertain.sample(rng, epoch).into()
     }
 }
@@ -56,7 +55,7 @@ macro_rules! logic_op {
             }
         }
 
-        impl<A, B> Uncertain for $name<A, B>
+        impl<A, B> UncertainBase for $name<A, B>
         where
             A: Uncertain,
             B: Uncertain,
@@ -65,7 +64,7 @@ macro_rules! logic_op {
         {
             type Value = bool;
 
-            fn sample<R: Rng + ?Sized>(&self, rng: &mut R, epoch: usize) -> Self::Value {
+            fn sample(&self, rng: &mut Rng, epoch: usize) -> Self::Value {
                 self.a.sample(rng, epoch).into() $op self.b.sample(rng, epoch).into()
             }
         }
@@ -95,7 +94,7 @@ macro_rules! binary_op {
             }
         }
 
-        impl<A, B> Uncertain for $name<A, B>
+        impl<A, B> UncertainBase for $name<A, B>
         where
             A: Uncertain,
             B: Uncertain,
@@ -103,7 +102,7 @@ macro_rules! binary_op {
         {
             type Value = <A::Value as std::ops::$trait<B::Value>>::Output;
 
-            fn sample<R: Rng + ?Sized>(&self, rng: &mut R, epoch: usize) -> Self::Value {
+            fn sample(&self, rng: &mut Rng, epoch: usize) -> Self::Value {
                 self.a.sample(rng, epoch) $op self.b.sample(rng, epoch)
             }
         }
@@ -120,15 +119,14 @@ binary_op!(Ratio, /, Div);
 
 #[cfg(test)]
 mod tests {
-    use crate::Uncertain;
-    use rand::Rng;
+    use crate::{Rng, Uncertain, UncertainBase};
 
     struct FixedValue<T>(T);
 
-    impl<T: Clone> Uncertain for FixedValue<T> {
+    impl<T: Clone> UncertainBase for FixedValue<T> {
         type Value = T;
 
-        fn sample<R: Rng + ?Sized>(&self, _rng: &mut R, _epoch: usize) -> T {
+        fn sample(&self, _rng: &mut Rng, _epoch: usize) -> T {
             self.0.clone()
         }
     }

--- a/src/adapters/ops.rs
+++ b/src/adapters/ops.rs
@@ -119,71 +119,61 @@ binary_op!(Ratio, /, Div);
 
 #[cfg(test)]
 mod tests {
-    use crate::{Rng, Uncertain};
-
-    struct FixedValue<T>(T);
-
-    impl<T: Clone> Uncertain for FixedValue<T> {
-        type Value = T;
-
-        fn sample(&self, _rng: &mut Rng, _epoch: usize) -> T {
-            self.0.clone()
-        }
-    }
+    use crate::{PointMass, Uncertain};
 
     #[test]
     fn op_not() {
-        let a = FixedValue(false);
+        let a = PointMass::new(false);
         assert!(a.not().pr(0.99999));
     }
 
     #[test]
     fn op_and() {
-        let a = FixedValue(true);
-        let b = FixedValue(true);
+        let a = PointMass::new(true);
+        let b = PointMass::new(true);
         assert!(a.and(b).pr(0.99999));
 
-        let a = FixedValue(true);
-        let b = FixedValue(false);
+        let a = PointMass::new(true);
+        let b = PointMass::new(false);
         assert_eq!(a.and(b).pr(0.00001), false);
     }
 
     #[test]
     fn op_or() {
-        let a = FixedValue(false);
-        let b = FixedValue(true);
+        let a = PointMass::new(false);
+        let b = PointMass::new(true);
         assert!(a.or(b).pr(0.99999));
 
-        let a = FixedValue(false);
-        let b = FixedValue(false);
+        let a = PointMass::new(false);
+        let b = PointMass::new(false);
         assert_eq!(a.or(b).pr(0.00001), false);
     }
 
     #[test]
     fn op_add() {
-        let a = FixedValue(5);
-        let b = FixedValue(9);
+        let a = PointMass::new(5);
+        let b = PointMass::new(9);
         assert!(a.add(b).map(|sum| sum == 5 + 9).pr(0.99999));
     }
 
     #[test]
     fn op_sub() {
-        let a = FixedValue(5);
-        let b = FixedValue(9);
+        let a = PointMass::new(5);
+        let b = PointMass::new(9);
         assert!(a.sub(b).map(|sum| sum == 5 - 9).pr(0.99999));
     }
 
     #[test]
     fn op_mul() {
-        let a = FixedValue(5);
-        let b = FixedValue(9);
+        let a = PointMass::new(5);
+        let b = PointMass::new(9);
         assert!(a.mul(b).map(|sum| sum == 5 * 9).pr(0.99999));
     }
 
     #[test]
     fn op_div() {
-        let a = FixedValue(5.0);
-        let b = FixedValue(9.0);
+        let a = PointMass::new(5.0);
+        let b = PointMass::new(9.0);
         assert!(a.div(b).map(|sum| sum == 5.0 / 9.0).pr(0.99999));
     }
 }

--- a/src/adapters/ops.rs
+++ b/src/adapters/ops.rs
@@ -1,4 +1,4 @@
-use crate::{Rng, Uncertain, UncertainBase};
+use crate::{Rng, Uncertain};
 
 pub struct Not<U>
 where
@@ -18,7 +18,7 @@ where
     }
 }
 
-impl<U> UncertainBase for Not<U>
+impl<U> Uncertain for Not<U>
 where
     U: Uncertain,
     U::Value: Into<bool>,
@@ -55,7 +55,7 @@ macro_rules! logic_op {
             }
         }
 
-        impl<A, B> UncertainBase for $name<A, B>
+        impl<A, B> Uncertain for $name<A, B>
         where
             A: Uncertain,
             B: Uncertain,
@@ -94,7 +94,7 @@ macro_rules! binary_op {
             }
         }
 
-        impl<A, B> UncertainBase for $name<A, B>
+        impl<A, B> Uncertain for $name<A, B>
         where
             A: Uncertain,
             B: Uncertain,
@@ -119,11 +119,11 @@ binary_op!(Ratio, /, Div);
 
 #[cfg(test)]
 mod tests {
-    use crate::{Rng, Uncertain, UncertainBase};
+    use crate::{Rng, Uncertain};
 
     struct FixedValue<T>(T);
 
-    impl<T: Clone> UncertainBase for FixedValue<T> {
+    impl<T: Clone> Uncertain for FixedValue<T> {
         type Value = T;
 
         fn sample(&self, _rng: &mut Rng, _epoch: usize) -> T {

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -1,4 +1,4 @@
-use crate::{Rng, Uncertain, UncertainBase};
+use crate::{Rng, Uncertain};
 use std::boxed::Box;
 
 /// An opaque uncertain value. This is useful when you need to conditionally
@@ -18,7 +18,7 @@ impl<T> BoxedUncertain<T> {
     }
 }
 
-impl<T> UncertainBase for BoxedUncertain<T> {
+impl<T> Uncertain for BoxedUncertain<T> {
     type Value = T;
 
     fn sample(&self, rng: &mut Rng, epoch: usize) -> Self::Value {

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -1,8 +1,10 @@
 use crate::{Rng, Uncertain};
 use std::boxed::Box;
 
-/// An opaque uncertain value. This is useful when you need to conditionally
-/// return different uncertain values. See [`into_boxed`](Uncertain::into_boxed).
+/// An opaque uncertain value.
+///
+/// This is useful when you need to conditionally return different uncertain values.
+/// See [`into_boxed`](Uncertain::into_boxed).
 pub struct BoxedUncertain<T> {
     ptr: Box<dyn Uncertain<Value = T> + Send>,
 }

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -1,4 +1,4 @@
-use crate::{Rng, UncertainBase};
+use crate::{Rng, Uncertain};
 use std::marker::PhantomData;
 
 /// Wraps a [`Distribution`](rand::distributions::Distribution) to create uncertain
@@ -28,7 +28,7 @@ where
     }
 }
 
-impl<T, D> UncertainBase for Distribution<T, D>
+impl<T, D> Uncertain for Distribution<T, D>
 where
     D: rand::distributions::Distribution<T>,
 {

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -1,31 +1,35 @@
 use crate::{Rng, Uncertain};
 use std::marker::PhantomData;
 
-/// Wraps a [`Distribution`](rand::distributions::Distribution) to create uncertain
-/// values from probability distributions and ensure they have the
-/// correct [`Copy`] and [`Clone`] semantics.
+/// Wraps a [`Distribution`](rand::distributions::Distribution) and implements
+/// [`Uncertain`](Uncertain).
+///
+/// Uncertain values need to observe the correct `epoch` semantics if
+/// they implement [`Copy`] or [`Clone`], or want to implement [`Uncertain`](Uncertain)
+/// for references.
+/// Since most uncertain values model distributions but distributions
+/// themselves do not require any special `epoch` semantics when they can be `Cloned` or
+/// are implemented on references, this wrapper type exists.
+///
+/// See [`Uncertain::sample`](Uncertain::sample) for more details on the required semantics.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use uncertain::{Uncertain, Distribution};
+/// use rand_distr::StandardNormal;
+///
+/// let x = Distribution::from(StandardNormal);
+/// assert!(x.map(|x: f64| x.abs() < 1.0).pr(0.68));
+/// ```
 pub struct Distribution<T, D>
 where
     D: rand::distributions::Distribution<T>,
 {
     dist: D,
     _p: PhantomData<T>,
-}
-
-impl<T, D> Distribution<T, D>
-where
-    D: rand::distributions::Distribution<T>,
-{
-    /// Construct a new [`impl Uncertain`] from a
-    /// distribution.
-    ///
-    /// [`impl Uncertain`]: crate::Uncertain
-    pub fn from(dist: D) -> Self {
-        Self {
-            dist,
-            _p: PhantomData {},
-        }
-    }
 }
 
 impl<T, D> Uncertain for Distribution<T, D>

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -1,5 +1,4 @@
-use crate::Uncertain;
-use rand::Rng;
+use crate::{Rng, UncertainBase};
 use std::marker::PhantomData;
 
 /// Wraps a [`Distribution`](rand::distributions::Distribution) to create uncertain
@@ -20,7 +19,7 @@ where
     /// Construct a new [`impl Uncertain`] from a
     /// distribution.
     ///
-    /// [`impl Uncertain`]: Uncertain
+    /// [`impl Uncertain`]: crate::Uncertain
     pub fn from(dist: D) -> Self {
         Self {
             dist,
@@ -29,13 +28,13 @@ where
     }
 }
 
-impl<T, D> Uncertain for Distribution<T, D>
+impl<T, D> UncertainBase for Distribution<T, D>
 where
     D: rand::distributions::Distribution<T>,
 {
     type Value = T;
 
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R, _epoch: usize) -> Self::Value {
+    fn sample(&self, rng: &mut Rng, _epoch: usize) -> Self::Value {
         self.dist.sample(rng)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,8 @@ pub trait Uncertain {
     /// uncertain value. This is similar to [`Distribution::sample`],
     /// with one important difference:
     ///
-    /// If the type which implements `UncertainBase` is either [`Copy`] or [`Clone`], or if
-    /// its references implement `UncertainBase`, then it must guarantee that it will return
+    /// If the type which implements `Uncertain` is either [`Copy`] or [`Clone`], or if
+    /// its references implement `Uncertain`, then it must guarantee that it will return
     /// the same value if queried consecutively with the same epoch (but different rng state).
     ///
     /// This is important when a value is reused within a computation. Consider the following

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,9 @@ pub use point::PointMass;
 
 pub(crate) type Rng = Pcg32;
 
-/// Methods required to sample from uncertain values.
-///
-/// You are probably looking for [`Uncertain`](crate::Uncertain).
-pub trait UncertainBase {
+/// An interface for using uncertain values in computations.
+#[must_use = "uncertain values are lazy and do nothing unless queried"]
+pub trait Uncertain {
     /// The type of the contained value.
     type Value;
 
@@ -97,11 +96,7 @@ pub trait UncertainBase {
     /// [`Distribution::sample`]: rand::distributions::Distribution::sample
     /// [`Into<Distribution>`]: Distribution
     fn sample(&self, rng: &mut Rng, epoch: usize) -> Self::Value;
-}
 
-/// An interface for using uncertain values in computations.
-#[must_use = "uncertain values are lazy and do nothing unless queried"]
-pub trait Uncertain: UncertainBase {
     /// Determine if the probability of obtaining `true` form this uncertain
     /// value is at least `probability`.
     ///
@@ -182,7 +177,7 @@ pub trait Uncertain: UncertainBase {
     /// Bundle this uncertain value with a cache, so it can be reused in a calculation.
     ///
     /// Uncertain values should normally not implement `Copy` or `Clone`, since the same value
-    /// is only allowed to be sampled once for every epoch (see [`sample`](UncertainBase::sample)).
+    /// is only allowed to be sampled once for every epoch (see [`sample`](Self::sample)).
     /// This wrapper allows a value to be reused by caching the sample result for every epoch and
     /// implementing [`Uncertain`] for references.
     ///
@@ -470,5 +465,3 @@ pub trait Uncertain: UncertainBase {
         Ratio::new(self, other)
     }
 }
-
-impl<U: UncertainBase> Uncertain for U {}

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,4 +1,4 @@
-use crate::{Rng, UncertainBase};
+use crate::{Rng, Uncertain};
 
 /// An uncertain value which is distributed as a
 /// point mass around a single value. This is useful
@@ -23,7 +23,7 @@ where
     }
 }
 
-impl<T> UncertainBase for PointMass<T>
+impl<T> Uncertain for PointMass<T>
 where
     T: Clone,
 {

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,9 +1,42 @@
 use crate::{Rng, Uncertain};
 
-/// An uncertain value which is distributed as a
-/// point mass around a single value. This is useful
-/// to express computations involving known values more
-/// easily.
+/// An uncertain value which always yields the same
+/// value.
+///
+/// This type can be useful when fixed values should
+/// be conditionally returned e.g. from [`flat_map`](Uncertain::flat_map).
+/// If you only need a fixed value as part of an uncertain computation, consider
+/// using [`map`](Uncertain::map).
+///
+/// # Examples
+///
+/// Basic usage: conditional distribution.
+///
+/// ```
+/// use uncertain::{Uncertain, PointMass, Distribution};
+/// use rand_distr::Normal;
+///
+/// let a = Distribution::from(Normal::new(2.0, 1.0).unwrap());
+/// let b = a.flat_map(|a| if a < 1.5 {
+///     Distribution::from(Normal::new(0.0, 1.0).unwrap()).into_boxed()
+/// } else {
+///     PointMass::new(1.0).into_boxed()
+/// });
+/// assert!(b.map(|b| b > 0.5).pr(0.9));
+/// ```
+///
+/// In most cases you can use [`map`](Uncertain::map) instead:
+///
+/// ```
+/// use uncertain::{Uncertain, PointMass, Distribution};
+/// use rand_distr::StandardNormal;
+///
+/// let x = 1.0;
+/// let y = Distribution::<f64, _>::from(StandardNormal).into_ref();
+/// let a = PointMass::new(x).add(&y);
+/// let b = (&y).map(|v: f64| v + x);
+/// assert!(a.join(b, |a, b| a == b).pr(0.999));
+/// ```
 #[derive(Clone, Copy)]
 pub struct PointMass<T>
 where
@@ -31,5 +64,22 @@ where
 
     fn sample(&self, _rng: &mut Rng, _epoch: usize) -> Self::Value {
         self.value.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Uncertain;
+    use rand_pcg::Pcg32;
+
+    #[test]
+    fn samples_are_always_the_same() {
+        let val = 42.0;
+        let point = PointMass::new(val);
+        let mut rng = Pcg32::new(0xcafef00dd15ea5e5, 0xa02bdbf7bb3c0a7);
+        for epoch in 0..100 {
+            assert_eq!(val, point.sample(&mut rng, epoch));
+        }
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,0 +1,35 @@
+use crate::{Rng, UncertainBase};
+
+/// An uncertain value which is distributed as a
+/// point mass around a single value. This is useful
+/// to express computations involving known values more
+/// easily.
+#[derive(Clone, Copy)]
+pub struct PointMass<T>
+where
+    T: Clone,
+{
+    value: T,
+}
+
+impl<T> PointMass<T>
+where
+    T: Clone,
+{
+    /// Create a new `PointMass` centered on
+    /// the given value.
+    pub fn new(value: T) -> Self {
+        Self { value }
+    }
+}
+
+impl<T> UncertainBase for PointMass<T>
+where
+    T: Clone,
+{
+    type Value = T;
+
+    fn sample(&self, _rng: &mut Rng, _epoch: usize) -> Self::Value {
+        self.value.clone()
+    }
+}

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -1,9 +1,9 @@
-use crate::{Rng, UncertainBase};
+use crate::{Rng, Uncertain};
 use std::cell::Cell;
 
 pub struct RefUncertain<U>
 where
-    U: UncertainBase,
+    U: Uncertain,
     U::Value: Clone,
 {
     uncertain: U,
@@ -12,7 +12,7 @@ where
 
 impl<U> RefUncertain<U>
 where
-    U: UncertainBase,
+    U: Uncertain,
     U::Value: Clone,
 {
     pub(crate) fn new(contained: U) -> Self {
@@ -23,9 +23,9 @@ where
     }
 }
 
-impl<U> UncertainBase for &RefUncertain<U>
+impl<U> Uncertain for &RefUncertain<U>
 where
-    U: UncertainBase,
+    U: Uncertain,
     U::Value: Clone,
 {
     type Value = U::Value;
@@ -40,21 +40,21 @@ where
     }
 }
 
-impl<U> UncertainBase for RefUncertain<U>
+impl<U> Uncertain for RefUncertain<U>
 where
-    U: UncertainBase,
+    U: Uncertain,
     U::Value: Clone,
 {
     type Value = U::Value;
 
     fn sample(&self, rng: &mut Rng, epoch: usize) -> Self::Value {
-        <&Self as UncertainBase>::sample(&self, rng, epoch)
+        <&Self as Uncertain>::sample(&self, rng, epoch)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{Distribution, Uncertain, UncertainBase};
+    use crate::{Distribution, Uncertain};
     use rand_distr::Normal;
     use rand_pcg::Pcg32;
 

--- a/src/sprt.rs
+++ b/src/sprt.rs
@@ -1,5 +1,5 @@
-use crate::Uncertain;
-use rand::Rng;
+use crate::UncertainBase;
+use rand_pcg::Pcg32;
 
 const D0: f32 = 0.999;
 const D1: f32 = 0.999;
@@ -29,11 +29,10 @@ fn log_likelyhood_ratio(prob: f32, val: bool) -> f32 {
     reject_likelyhood(prob, val).ln() - accept_likelyhood(prob, val).ln()
 }
 
-pub fn sequential_probability_ratio_test<U, R>(prob: f32, src: &U, rng: &mut R) -> bool
+pub fn sequential_probability_ratio_test<U>(prob: f32, src: &U, rng: &mut Pcg32) -> bool
 where
-    U: Uncertain + ?Sized,
+    U: UncertainBase + ?Sized,
     U::Value: Into<bool>,
-    R: Rng + ?Sized,
 {
     let upper_ln = (D1 / (1.0 - D1)).ln();
     let lower_ln = ((1.0 - D0) / D0).ln();

--- a/src/sprt.rs
+++ b/src/sprt.rs
@@ -1,4 +1,4 @@
-use crate::UncertainBase;
+use crate::Uncertain;
 use rand_pcg::Pcg32;
 
 const D0: f32 = 0.999;
@@ -31,7 +31,7 @@ fn log_likelyhood_ratio(prob: f32, val: bool) -> f32 {
 
 pub fn sequential_probability_ratio_test<U>(prob: f32, src: &U, rng: &mut Pcg32) -> bool
 where
-    U: UncertainBase + ?Sized,
+    U: Uncertain + ?Sized,
     U::Value: Into<bool>,
 {
     let upper_ln = (D1 / (1.0 - D1)).ln();


### PR DESCRIPTION
Currently contemplating what design would be best.

The choices seem to be:
1. Have sample be generic over RNG, and somehow force a specific generator when sampling through `BoxedUncertain`
2. Remove the generic RNG support