### PR TITLE
stop relying on type inference edge case to support `-Znext-solver`

### DIFF
--- a/tests/basic_expect.rs
+++ b/tests/basic_expect.rs
@@ -76,10 +76,10 @@ fn very_hard() {
 #[test]
 fn composite_gaussian_poisson() {
     let g = Distribution::from(Normal::new(5.0, 2.0).unwrap());
-    let p = Distribution::from(Poisson::new(3.0).unwrap());
+    let p = Distribution::from(Poisson::new(3.0f64).unwrap());
     let s = g.add(p);
 
-    let mu = s.expect(0.1 as f64);
+    let mu = s.expect(0.1);
     assert!(mu.is_ok());
     assert!((mu.unwrap() - 8.0).abs() < 0.1);
 }


### PR DESCRIPTION
The test `basic_expect::composite_gaussian_poisson` relies on a very subtle type inference edge case of the current implementation. We are currently working towards the [next-generation trait solver](https://blog.rust-lang.org/inside-rust/2023/07/17/trait-system-refactor-initiative/) which will no longer support this specific edge-case. We encountered this issue during [a crater run](https://github.com/rust-lang/crater) with the new solver in https://github.com/rust-lang/rust/pull/133502.

The core issue is that we generally do not reason about the "projected-to" type of ambiguous associated types. So if you've got the ambiguous associated type `<_ as Uncertain>::Assoc` and equate it to two separate types, this does not require these two types to be equal. Said concisely: `A eq <_ as Uncertain>::Assoc eq B` currently does not imply `A == B` in the *implementation* of Rust, even though this does hold in theory.

There are edge-cases where this implication does hold due to implementation details of the used caching strategy. This concrete case is supported by our old caching approach but will not be with our new one. For a more technical deep-dive, see https://github.com/rust-lang/trait-system-refactor-initiative/issues/215.

I am sorry for the inconvenience and please ask in case you have any questions.